### PR TITLE
Bug fixes

### DIFF
--- a/pysurge/pysurge.py
+++ b/pysurge/pysurge.py
@@ -188,14 +188,10 @@ class TestRunner:
         workers = rate_of_fire * max_duration
 
         executor = ThreadPoolExecutor(max_workers=workers)
-        last_submit_time = 0.0
 
         while not self._stop.is_set():
-            if time.time() - last_submit_time >= rate_of_fire:
-                last_submit_time = time.time()
-                executor.submit(self._test_runner)
-            # Sleep for short durations so we can quickly catch the _stop flag being set
-            time.sleep(0.1)
+            executor.submit(self._test_runner)
+            time.sleep(rate_of_fire)
 
         executor.shutdown()
 

--- a/pysurge/pysurge.py
+++ b/pysurge/pysurge.py
@@ -183,12 +183,14 @@ class TestRunner:
         """Handles the continuous loop to submit tests to the thread pool executor."""
         start_time = time.time()
 
-        rate_of_fire = 1.0 / self.rate
         max_duration = self.test_instance.max_duration
-        workers = rate_of_fire * max_duration
+        # Based on Little's Law
+        # Max number of concurrent tests = (num tests fired/sec) * (max duration in sec of test)
+        workers = self.rate * max_duration
 
         executor = ThreadPoolExecutor(max_workers=workers)
 
+        rate_of_fire = 1.0 / self.rate  # 1 test fired every 'rate_of_fire' seconds
         while not self._stop.is_set():
             executor.submit(self._test_runner)
             time.sleep(rate_of_fire)

--- a/pysurge/pysurge.py
+++ b/pysurge/pysurge.py
@@ -196,7 +196,7 @@ class TestRunner:
             try:
                 executor.submit(self._test_runner)
             except RuntimeError as err:
-                if str(err) == "can't start new thread":
+                if "can't start new thread" in str(err):
                     log.error("unable to start new thread! desired rate won't be achieved")
                 else:
                     raise

--- a/pysurge/pysurge.py
+++ b/pysurge/pysurge.py
@@ -191,8 +191,16 @@ class TestRunner:
         executor = ThreadPoolExecutor(max_workers=workers)
 
         rate_of_fire = 1.0 / self.rate  # 1 test fired every 'rate_of_fire' seconds
+
         while not self._stop.is_set():
-            executor.submit(self._test_runner)
+            try:
+                executor.submit(self._test_runner)
+            except RuntimeError as err:
+                if str(err) == "can't start new thread":
+                    log.error("unable to start new thread! desired rate won't be achieved")
+                else:
+                    raise
+
             time.sleep(rate_of_fire)
 
         executor.shutdown()


### PR DESCRIPTION
* Sleep for rate_of_fire when running: By calling `time.sleep(0.1)` here we are limiting how fast tests can actually fire. They would never fire more often than every 0.1 sec.
* Fix use of Little's Law. It should be "time of arrival in sec" * "duration in sec" instead of "rate of fire" (which is 1 / sec) * "duration in sec"
* Handle RuntimeError when unable to create a new thread. We'll just log a warning and carry on. The consequence would be that we simply cannot fire as many tests as we've been asked to.

Fixes #2 